### PR TITLE
perf: 通过网域连接k8s时支持默认端口

### DIFF
--- a/apps/assets/utils/k8s.py
+++ b/apps/assets/utils/k8s.py
@@ -66,7 +66,7 @@ class KubernetesClient:
 
         remote_bind_address = (
             urlparse(asset.address).hostname,
-            urlparse(asset.address).port
+            urlparse(asset.address).port or 443
         )
         server = SSHTunnelForwarder(
             (gateway.address, gateway.port),


### PR DESCRIPTION
#### What this PR does / why we need it?

Kubernetes apiserver endpoint 可能为默认的443端口，而会被忽略，例如腾讯云TKE `https://cls-xxxxxxx.ccs.tencent-cloud.com`

通过网域连接kubernetes资产时，建立ssh隧道时需要提供远端的端口号，`urlparse`库在端口省略时返回`None`，导致报错`PORT is not a number`

#### Summary of your change

kubernetes endpoint必然为https协议，设置默认端口为443

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.